### PR TITLE
Fix syntax errors in regex_patterns by adding comma

### DIFF
--- a/swaggerspy.py
+++ b/swaggerspy.py
@@ -48,7 +48,7 @@ regex_patterns = {
 	'NPM Access Token'  : r'npm_[a-zA-Z0-9]{36}',
 	'GitHub Personal Access Token (PAT)'  : r'ghp_[a-zA-Z0-9]{36}',
 	'Git Credential'  : r'https?:\/\/[a-zA-Z0-9_-]+:[a-zA-Z0-9_-]+@github\.com',
-	'JIRA Personal Access Token (PAT) Regex'  : r'ATATTAC[a-zA-Z0-9]{24,48}'
+	'JIRA Personal Access Token (PAT) Regex'  : r'ATATTAC[a-zA-Z0-9]{24,48}',
 	'possible_Creds' : r'(?i)(" \
 					r"password\s*[`=:\"]+\s*[^\s]+|" \
 					r"password is\s*[`=:\"]*\s*[^\s]+|" \


### PR DESCRIPTION
Line 52 is missing a trailing comma after the Jira PAT entry, causing invalid syntax error in Python. Fixed it by adding comma on line 51. Tested and it works fine now.